### PR TITLE
Reference section 5.4.1 of RFC 2181 and Section 2.2 of RFC 1035 directly

### DIFF
--- a/draft-fujiwara-dnsop-ranking-data.mkd
+++ b/draft-fujiwara-dnsop-ranking-data.mkd
@@ -34,7 +34,7 @@ informative:
 
 --- abstract
 
-This document obsoletes Section 5.4.1 of {{!RFC2181}}, the Ranking data
+This document obsoletes {{Section 5.4.1 (Ranking data) of !RFC2181}},
 and specifies how to handle DNS data.
 
 --- middle
@@ -42,11 +42,11 @@ and specifies how to handle DNS data.
 Introduction {#introduction}
 =====
 
-This document replaces Section 5.4.1 of {RFC2181}, the Ranking data
+This document obsoletes {{Section 5.4.1 (Ranking data) of !RFC2181}},
 and specifies how to handle DNS data.
 
-The DNS server assumed in {RFC2181} The Ranking Data is considered to
-be a model with a shared database described in RFC 1035 Page 5 that
+The DNS server assumed in {{Section 5.4.1 (Ranking data) of !RFC2181}} is considered to
+be a model with a shared database described in {{Section 2.2 (Common configurations) of !RFC1035}} that
 has both Authoritative server and Recursive Resolver functions.
 It is assumed that information obtained from zone files, zone transfers,
 and name resolution will be mixed together.
@@ -61,11 +61,7 @@ obtained from name resolution.
 Terminology {#terminology}
 =========
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
-"SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
-"OPTIONAL" in this document are to be interpreted as described in 
-BCP14 {{!RFC2119}} {{!RFC8174}} when, and only when, they appear in all
-capitals, as shown here.
+{::boilerplate bcp14-tagged}
 
 Many of the specialized terms used in this document are defined in
 DNS Terminology {{!RFC9499}}.
@@ -73,8 +69,8 @@ DNS Terminology {{!RFC9499}}.
 Problem Statement
 =================
 
-The DNS server assumed in {RFC2181} The Ranking Data is considered to
-be a model with a shared database described in RFC 1035 Page 5 that
+The DNS server assumed in {{Section 5.4.1 (Ranking data) of !RFC2181}} is considered to
+be a model with a shared database described in {{Section 2.2 (Common configurations) of !RFC1035}} that
 has both Authoritative server and Recursive Resolver functions.
 It is assumed that information obtained from zone files, zone transfers,
 and name resolution will be mixed together.


### PR DESCRIPTION
Also uses a kramdown-rfc2629 to include terminology boiler plate directly