### PR TITLE
An additional directive for the priming function

### DIFF
--- a/draft-fujiwara-dnsop-ranking-data.mkd
+++ b/draft-fujiwara-dnsop-ranking-data.mkd
@@ -122,7 +122,7 @@ R3. Non-authoritative responses (referral/delegation responses) from
   authoritative servers MUST only be used to query the delegated
   authoritative server during the name resolution.
 
-R4. Names and IP addresses of the authoritative name servers for zones (such as the root zone) that are built-in or loaded from "hints" files, MUST only be used for priming a resolver for those zones {{!BCP209}}.
+R4. Names and IP addresses of the authoritative name servers for zones (such as the root zone) that are built-in or loaded from "hints" files, MUST only be used for priming a resolver for those zones {{!RFC9609}}.
 
 Additional Considerations
 =================

--- a/draft-fujiwara-dnsop-ranking-data.mkd
+++ b/draft-fujiwara-dnsop-ranking-data.mkd
@@ -122,6 +122,8 @@ R3. Non-authoritative responses (referral/delegation responses) from
   authoritative servers MUST only be used to query the delegated
   authoritative server during the name resolution.
 
+R4. Names and IP addresses of the authoritative name servers for zones (such as the root zone) that are built-in or loaded from "hints" files, MUST only be used for priming a resolver for those zones {{!BCP209}}.
+
 Additional Considerations
 =================
 


### PR DESCRIPTION
So that resolvers use the built-in names and IP addresses, or those from hints files, only for priming.